### PR TITLE
Image uploading optimizations

### DIFF
--- a/resources/js/components/EditItemForm.js
+++ b/resources/js/components/EditItemForm.js
@@ -34,6 +34,8 @@ const EditItemForm = ({ selectedItem, setSelectedItem, onSubmitItem }) => {
   }
 
   const onSelectUnsplashImage = (urls) => {
+    //downsize here
+    urls.download += "&w=500&fit=cover";
     setItemImages_new([...itemImages_new, { urls }]);
   }
 

--- a/resources/js/components/ImageUploader.js
+++ b/resources/js/components/ImageUploader.js
@@ -1,10 +1,20 @@
 import React from 'react';
+import { toast } from 'react-toastify';
 import { Button, Segment } from "semantic-ui-react";
 
 
 const ImageUploader = ({ onUploadImages, imageCount = null, formID = "image-uploader" }) => {
 
     const onFileChange = (event) => {
+        if (!event.target.files[0]) return;
+
+        for (let i = 0; i < event.target.files.length; i++) {
+            if (event.target.files[i].size > 2000000) {
+                toast("One or more of the inputted files exceeds 2MB. Please select images less than 2MB!", "error");
+                return;
+            }
+        }
+
         onUploadImages([...event.target.files]);
     }
 
@@ -14,11 +24,11 @@ const ImageUploader = ({ onUploadImages, imageCount = null, formID = "image-uplo
 
     let count;
 
-    if(imageCount === null || imageCount === undefined) count = null;
-    else{
+    if (imageCount === null || imageCount === undefined) count = null;
+    else {
         count = imageCount > 0
-        ? <p>{imageCount} Images Selected</p>
-        : <p>No Images Selected</p>
+            ? <p>{imageCount} Images Selected</p>
+            : <p>No Images Selected</p>
     }
     return (
         <div>
@@ -32,7 +42,7 @@ const ImageUploader = ({ onUploadImages, imageCount = null, formID = "image-uplo
                 name="file"
                 accept="image/*"
                 onChange={(e) => onFileChange(e)} />
-            </div>
+        </div>
     );
 }
 

--- a/resources/js/components/views/Edit.js
+++ b/resources/js/components/views/Edit.js
@@ -95,6 +95,7 @@ function Edit() {
     }
 
     const onSelectUnsplashImageSet = (urls) => {
+        urls.download += "&w=500&fit=cover";
         setSetImages_new([...setImages_new, { urls }]);
     }
 


### PR DESCRIPTION
[#170 ]
- User cannot select image greater than 2 megabytes in size
- Unsplash images are scaled down before storing